### PR TITLE
fix: fix Window::all() panic in macos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xcap"
-version = "0.0.5"
+version = "0.0.6"
 edition = "2021"
 description = "XCap is a cross-platform screen capture library written in Rust. It supports Linux (X11, Wayland), MacOS, and Windows. XCap supports screenshot and video recording (to be implemented)."
 license = "Apache-2.0"

--- a/src/macos/impl_window.rs
+++ b/src/macos/impl_window.rs
@@ -66,7 +66,7 @@ fn get_window_cg_rect(window_cf_dictionary_ref: CFDictionaryRef) -> CGRect {
 impl ImplWindow {
     pub fn new(
         window_cf_dictionary_ref: CFDictionaryRef,
-        impl_monitors: &Vec<ImplMonitor>,
+        impl_monitors: &[ImplMonitor],
     ) -> XCapResult<ImplWindow> {
         unsafe {
             let id = {


### PR DESCRIPTION
* fix #113 