### PR TITLE
Wayland : Fix multithreading bug + fix segfault in libdubs on certain systems.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ windows = { version = "0.58", features = [
 [target.'cfg(target_os="linux")'.dependencies]
 percent-encoding = "2.3"
 xcb = { version = "1.4", features = ["randr"] }
-dbus = { version = "0.9", features = ["vendored"] }
+dbus = { version = "0.9.7" }
 
 [dev-dependencies]
 fs_extra = "1.3"

--- a/src/linux/wayland_capture.rs
+++ b/src/linux/wayland_capture.rs
@@ -172,9 +172,8 @@ pub fn wayland_capture(impl_monitor: &ImplMonitor) -> XCapResult<RgbaImage> {
     let y = ((impl_monitor.y as f32) * impl_monitor.scale_factor) as i32;
     let width = ((impl_monitor.width as f32) * impl_monitor.scale_factor) as i32;
     let height = ((impl_monitor.height as f32) * impl_monitor.scale_factor) as i32;
-
-    let conn = Connection::new_session()?;
     let lock = DBUS_LOCK.lock();
+    let conn = Connection::new_session()?;
     let res = org_gnome_shell_screenshot(&conn, x, y, width, height)
         .or_else(|_| org_freedesktop_portal_screenshot(&conn, x, y, width, height));
     drop(lock);
@@ -189,7 +188,7 @@ fn screnshot_multithreaded() {
         }
     }
     // Try making screenshots in paralel. If this times out, then this means that there is a threading issue.
-    const PARALELISM: usize = 1;
+    const PARALELISM: usize = 10;
     let handles: Vec<_> = (0..PARALELISM)
         .map(|_| {
             std::thread::spawn(|| {


### PR DESCRIPTION
This PR fixes two issues I had encountered with `xcap`.

1. Due to a bug in `xcap`, taking[ more than one screenshoot at a time ](https://github.com/nashaofu/xcap/issues/155#issue-2564845225)would cause XCapError("Screenshot failed or canceled"). 

This was caused by dbus messages getting lost when multiple threads interacted with dbus.

This  seems like a multi-threading bug, probably caused either by improper `dbus` usage. 

This PR fixes this issue, by ensuring no more than 2 threads can take a screenshot at any given time, using a `Mutex`.

I have also included a test, which demonstrates the original bug, and allows for checking if it has returned.

2. Segfaults in `libdbus`. 

For unclear reasons(I am still trying to figure them out with the maintainer[ of  the`dbus` crate](https://github.com/diwic/dbus-rs/issues/486)), using the `vendored` feature of `dbus` causes crashes(segfaults) on certain systems. 

As a workaround, this PR turns the `vendored` feature off, to allow `xcap` to work reliably on all systems.