### PR TITLE
使用window注册表替换sysinfo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ vendored = ["dbus/vendored"]
 [dependencies]
 image = "0.25"
 log = "0.4"
-sysinfo = "0.33"
 thiserror = "2.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
@@ -33,6 +32,7 @@ windows = { version = "0.58", features = [
     "Win32_Storage_Xps",
     "Win32_System_Threading",
     "Win32_System_ProcessStatus",
+    "Win32_System_Registry",
     "Win32_Storage_FileSystem",
     "Win32_Graphics_Dxgi",
     "Win32_Graphics_Direct3D",


### PR DESCRIPTION
只有window用到了判断系统版本，没必要导入sysinfo这个库，编译后可以减少大概600kb的体积
