### PR TITLE
添加image默认依赖为可选features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ keywords = ["screen", "monitor", "window", "capture", "image"]
 
 [features]
 vendored = ["dbus/vendored"]
-
+default-image = ["image/default"]
 [dependencies]
-image = "0.25"
+image = { version = "0.25", default-features = false, features = ["png"] }
 log = "0.4"
 sysinfo = "0.33"
 thiserror = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["screen", "monitor", "window", "capture", "image"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+default = ["default-image"]
 vendored = ["dbus/vendored"]
 default-image = ["image/default"]
 [dependencies]


### PR DESCRIPTION
添加image默认依赖为可选features，默认只开启png格式的编译后可以减少大概6M的体积，如果想开启全部可以使用default-image特性