### PR TITLE
fix: get `is_focused` value dynamically

### DIFF
--- a/examples/focused_window.rs
+++ b/examples/focused_window.rs
@@ -4,9 +4,9 @@ use xcap::Window;
 fn main() {
     thread::sleep(std::time::Duration::from_secs(3));
 
-    loop {
-        let windows = Window::all().unwrap();
+    let windows = Window::all().unwrap();
 
+    loop {
         windows.iter().filter(|w| w.is_focused()).for_each(|focused| {
             println!(
                 "Focused Window:\n id: {}\n title: {}\n app_name: {}\n monitor: {:?}\n position: {:?}\n size {:?}\n state {:?}\n",

--- a/examples/focused_window.rs
+++ b/examples/focused_window.rs
@@ -1,0 +1,25 @@
+use std::thread;
+use xcap::Window;
+
+fn main() {
+    thread::sleep(std::time::Duration::from_secs(3));
+
+    loop {
+        let windows = Window::all().unwrap();
+
+        windows.iter().filter(|w| w.is_focused()).for_each(|focused| {
+            println!(
+                "Focused Window:\n id: {}\n title: {}\n app_name: {}\n monitor: {:?}\n position: {:?}\n size {:?}\n state {:?}\n",
+                focused.id(),
+                focused.title(),
+                focused.app_name(),
+                focused.current_monitor().name(),
+                (focused.x(), focused.y(), focused.z()),
+                (focused.width(), focused.height()),
+                (focused.is_minimized(), focused.is_maximized(), focused.is_focused())
+            );
+        });
+
+        thread::sleep(std::time::Duration::from_secs(1));
+    }
+}

--- a/src/macos/impl_window.rs
+++ b/src/macos/impl_window.rs
@@ -11,6 +11,7 @@ use objc2_core_graphics::{
     CGDisplayBounds, CGMainDisplayID, CGRectContainsPoint, CGRectIntersectsRect,
     CGRectMakeWithDictionaryRepresentation, CGWindowListCopyWindowInfo, CGWindowListOption,
 };
+use objc2_foundation::{NSNumber, NSString};
 
 use crate::{error::XCapResult, XCapError};
 
@@ -177,9 +178,12 @@ impl ImplWindow {
         unsafe {
             let impl_monitors = ImplMonitor::all()?;
             let workspace = NSWorkspace::sharedWorkspace();
+            let pid_key = NSString::from_str("NSApplicationProcessIdentifier");
             let focused_app_pid = workspace
-                .frontmostApplication()
-                .map(|focused_app| focused_app.processIdentifier());
+                .activeApplication()
+                .and_then(|dictionary| dictionary.valueForKey(&pid_key))
+                .and_then(|pid| pid.downcast::<NSNumber>().ok())
+                .map(|pid| pid.intValue());
 
             let mut impl_windows = Vec::new();
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -76,7 +76,7 @@ impl Window {
     }
     /// The window is focused.
     pub fn is_focused(&self) -> bool {
-        self.impl_window.is_focused
+        self.impl_window.is_focused()
     }
 }
 

--- a/src/windows/impl_window.rs
+++ b/src/windows/impl_window.rs
@@ -51,8 +51,6 @@ pub(crate) struct ImplWindow {
     pub height: u32,
     pub is_minimized: bool,
     pub is_maximized: bool,
-    pub is_focused: bool,
-}
 
 fn is_window_cloaked(hwnd: HWND) -> bool {
     unsafe {
@@ -330,7 +328,6 @@ impl ImplWindow {
             let rc_client = window_info.rcClient;
             let is_minimized = IsIconic(hwnd).as_bool();
             let is_maximized = IsZoomed(hwnd).as_bool();
-            let is_focused = GetForegroundWindow() == hwnd;
 
             Ok(ImplWindow {
                 hwnd,
@@ -347,9 +344,12 @@ impl ImplWindow {
                 height: (rc_client.bottom - rc_client.top) as u32,
                 is_minimized,
                 is_maximized,
-                is_focused,
             })
         }
+    }
+
+    pub fn is_focused(&self) -> bool {
+        unsafe { GetForegroundWindow() == self.hwnd }
     }
 
     pub fn all() -> XCapResult<Vec<ImplWindow>> {

--- a/src/windows/impl_window.rs
+++ b/src/windows/impl_window.rs
@@ -51,6 +51,7 @@ pub(crate) struct ImplWindow {
     pub height: u32,
     pub is_minimized: bool,
     pub is_maximized: bool,
+}
 
 fn is_window_cloaked(hwnd: HWND) -> bool {
     unsafe {


### PR DESCRIPTION
closes #190

- **feat: write example to test against**
- **feat: use `activeApplication` to get focused app**
