### PR TITLE
windows: capture the window of current process

### DIFF
--- a/src/windows/impl_window.rs
+++ b/src/windows/impl_window.rs
@@ -14,9 +14,7 @@ use windows::{
         Storage::FileSystem::{GetFileVersionInfoSizeW, GetFileVersionInfoW, VerQueryValueW},
         System::{
             ProcessStatus::{GetModuleBaseNameW, GetModuleFileNameExW},
-            Threading::{
-                GetCurrentProcess, GetCurrentProcessId, PROCESS_QUERY_LIMITED_INFORMATION,
-            },
+            Threading::{GetCurrentProcess, PROCESS_QUERY_LIMITED_INFORMATION},
         },
         UI::WindowsAndMessaging::{
             EnumWindows, GetClassNameW, GetForegroundWindow, GetWindowInfo, GetWindowLongPtrW,
@@ -112,21 +110,6 @@ fn is_valid_window(hwnd: HWND) -> bool {
             {
                 return false;
             }
-        }
-
-        // GetWindowText* are potentially blocking operations if `hwnd` is
-        // owned by the current process. The APIs will send messages to the window's
-        // message loop, and if the message loop is waiting on this operation we will
-        // enter a deadlock.
-        // https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getwindowtexta#remarks
-        //
-        // To help consumers avoid this, there is a DesktopCaptureOption to ignore
-        // windows owned by the current process. Consumers should either ensure that
-        // the thread running their message loop never waits on this operation, or use
-        // the option to exclude these windows from the source list.
-        let lp_dw_process_id = get_window_pid(hwnd);
-        if lp_dw_process_id == GetCurrentProcessId() {
-            return false;
         }
 
         // Skip Program Manager window.

--- a/src/windows/impl_window.rs
+++ b/src/windows/impl_window.rs
@@ -101,12 +101,12 @@ fn is_valid_window(hwnd: HWND) -> bool {
         }
 
         let gwl_ex_style = WINDOW_EX_STYLE(GetWindowLongPtrW(hwnd, GWL_EXSTYLE) as u32);
-        let title = get_window_title(hwnd).unwrap_or_default();
 
         // 过滤掉具有 WS_EX_TOOLWINDOW 样式的窗口
         if gwl_ex_style.contains(WS_EX_TOOLWINDOW) {
             // windows 任务栏可以捕获
-            if class_name.cmp(&String::from("Shell_TrayWnd")) != Ordering::Equal && title.is_empty()
+            if class_name.cmp(&String::from("Shell_TrayWnd")) != Ordering::Equal
+                && get_window_title(hwnd).map_or(true, |title| title.is_empty())
             {
                 return false;
             }


### PR DESCRIPTION
According to `webrtc`, `GetWindowTextW` is not always safe to call. However, we call it unconditionally now, but exclude the current process window.

I'm trying to use `SendMessageTimeoutW` as suggested by https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getwindowtexta#remarks, and `500ms` is an arbitrary choosed number (`50ms` doesn't work sometimes). I can revert it if you prefer the old `GetWindowTextW` since it works just now.