### PR TITLE
feat(wayland): support image capture on `wlroot` wayland

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ dbus = "0.9"
 lazy_static = "1.5"
 percent-encoding = "2.3"
 xcb = { version = "1.5", features = ["randr"] }
+libwayshot = "0.3"
 
 [dev-dependencies]
 fs_extra = "1.3"

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,6 +30,9 @@ pub enum XCapError {
     #[cfg(target_os = "linux")]
     #[error(transparent)]
     StdTimeSystemTimeError(#[from] std::time::SystemTimeError),
+    #[cfg(target_os = "linux")]
+    #[error(transparent)]
+    LibwayshotError(#[from] libwayshot::Error),
 
     #[cfg(target_os = "macos")]
     #[error("Objc2CoreGraphicsCGError {:?}", 0)]

--- a/src/linux/wayland_capture.rs
+++ b/src/linux/wayland_capture.rs
@@ -186,12 +186,15 @@ fn wlroots_screenshot(
         height,
     };
     let rgba_image = wayshot_connection.screenshot(capture_region, false)?;
-    let width = rgba_image.width();
-    let height = rgba_image.height();
 
     // libwayshot returns image 0.24 RgbaImage
     // we need image 0.25 RgbaImage
-    let image = image::RgbaImage::from_raw(width, height, rgba_image.into_raw()).unwrap();
+    let image = image::RgbaImage::from_raw(
+        rgba_image.width(),
+        rgba_image.height(),
+        rgba_image.into_raw(),
+    )
+    .unwrap();
 
     Ok(image)
 }

--- a/src/linux/wayland_capture.rs
+++ b/src/linux/wayland_capture.rs
@@ -187,14 +187,11 @@ fn wlroots_screenshot(
     };
     let rgba_image = wayshot_connection.screenshot(capture_region, false)?;
     let width = rgba_image.width();
-    let height = rgba_image.width();
+    let height = rgba_image.height();
 
     // libwayshot returns image 0.24 RgbaImage
     // we need image 0.25 RgbaImage
-    let image_bytes = rgba_image.into_raw();
-
-    let image = image::RgbaImage::from_raw(width, height, image_bytes)
-        .expect("Conversion of PNG -> Raw -> PNG does not fail");
+    let image = image::RgbaImage::from_raw(width, height, rgba_image.into_raw()).unwrap();
 
     Ok(image)
 }

--- a/src/linux/wayland_capture.rs
+++ b/src/linux/wayland_capture.rs
@@ -172,12 +172,40 @@ fn org_freedesktop_portal_screenshot(
 
 static DBUS_LOCK: Mutex<()> = Mutex::new(());
 
+fn wlroots_screenshot(
+    x_coordinate: i32,
+    y_coordinate: i32,
+    width: i32,
+    height: i32,
+) -> XCapResult<RgbaImage> {
+    let wayshot_connection = libwayshot::WayshotConnection::new()?;
+    let capture_region = libwayshot::CaptureRegion {
+        x_coordinate,
+        y_coordinate,
+        width,
+        height,
+    };
+    let rgba_image = wayshot_connection.screenshot(capture_region, false)?;
+    let width = rgba_image.width();
+    let height = rgba_image.width();
+
+    // libwayshot returns image 0.24 RgbaImage
+    // we need image 0.25 RgbaImage
+    let image_bytes = rgba_image.into_raw();
+
+    let image = image::RgbaImage::from_raw(width, height, image_bytes)
+        .expect("Conversion of PNG -> Raw -> PNG does not fail");
+
+    Ok(image)
+}
+
 pub fn wayland_capture(x: i32, y: i32, width: i32, height: i32) -> XCapResult<RgbaImage> {
     let lock = DBUS_LOCK.lock();
 
     let conn = Connection::new_session()?;
     let res = org_gnome_shell_screenshot(&conn, x, y, width, height)
-        .or_else(|_| org_freedesktop_portal_screenshot(&conn, x, y, width, height));
+        .or_else(|_| org_freedesktop_portal_screenshot(&conn, x, y, width, height))
+        .or_else(|_| wlroots_screenshot(x, y, width, height));
 
     drop(lock);
 

--- a/src/linux/wayland_capture.rs
+++ b/src/linux/wayland_capture.rs
@@ -194,7 +194,7 @@ fn wlroots_screenshot(
         rgba_image.height(),
         rgba_image.into_raw(),
     )
-    .unwrap();
+    .expect("Conversion of PNG -> Raw -> PNG does not fail");
 
     Ok(image)
 }


### PR DESCRIPTION
This allows the library to take screenshots on wayland compositors using wlroots such as Sway

Closes #198