### PR TITLE
fix(linux): add Wayland scaling and update libwayshot

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,8 +60,7 @@ pipewire = "0.8"
 lazy_static = "1.5"
 percent-encoding = "2.3"
 xcb = { version = "1.5", features = ["randr"] }
-libwayshot = "0.3"
-
+libwayshot = { git = "https://github.com/waycrate/wayshot", rev = "9d5478ab340895a295d7ce169c4487fcc22c6275" }
 [dev-dependencies]
 fs_extra = "1.3"
 

--- a/src/linux/impl_monitor.rs
+++ b/src/linux/impl_monitor.rs
@@ -18,7 +18,10 @@ use crate::{
 use super::{
     capture::capture_monitor,
     impl_video_recorder::ImplVideoRecorder,
-    utils::{get_atom, get_current_screen_buf, get_monitor_info_buf, get_xcb_connection_and_index},
+    utils::{
+        get_atom, get_current_screen_buf, get_monitor_info_buf, get_xcb_connection_and_index,
+        wayland_detect,
+    },
 };
 
 #[derive(Debug, Clone)]
@@ -30,7 +33,7 @@ pub(crate) struct ImplMonitor {
 fn get_current_frequency(mode_infos: Vec<ModeInfo>, mode: Mode) -> f32 {
     let mode_info = match mode_infos.iter().find(|m| m.id == mode.resource_id()) {
         Some(mode_info) => mode_info,
-        None => return 0.0,
+        _ => return 0.0,
     };
 
     let vtotal = {
@@ -52,6 +55,23 @@ fn get_current_frequency(mode_infos: Vec<ModeInfo>, mode: Mode) -> f32 {
 }
 
 fn get_scale_factor() -> XCapResult<f32> {
+    if wayland_detect() {
+        // for wayland we can get all the outputs, and get the maximum scaling of them.
+        let wayshot_conn = libwayshot::WayshotConnection::new()?;
+
+        let max_scale = wayshot_conn
+            .get_all_outputs()
+            .iter()
+            .map(|output_info| {
+                output_info.physical_size.height as f64
+                    / output_info.logical_region.inner.size.height as f64
+            })
+            .reduce(f64::max)
+            .unwrap_or(0.);
+
+        return Ok(max_scale as f32);
+    }
+
     let (conn, _) = get_xcb_connection_and_index()?;
 
     let screen_buf = get_current_screen_buf()?;

--- a/src/linux/wayland_capture.rs
+++ b/src/linux/wayland_capture.rs
@@ -101,11 +101,17 @@ fn wlroots_screenshot(
     height: i32,
 ) -> XCapResult<RgbaImage> {
     let wayshot_connection = libwayshot::WayshotConnection::new()?;
-    let capture_region = libwayshot::CaptureRegion {
-        x_coordinate,
-        y_coordinate,
-        width,
-        height,
+    let capture_region = libwayshot::region::LogicalRegion {
+        inner: libwayshot::region::Region {
+            position: libwayshot::region::Position {
+                x: x_coordinate,
+                y: y_coordinate,
+            },
+            size: libwayshot::region::Size {
+                width: width as u32,
+                height: height as u32,
+            },
+        },
     };
     let rgba_image = wayshot_connection.screenshot(capture_region, false)?;
 
@@ -114,7 +120,7 @@ fn wlroots_screenshot(
     let image = image::RgbaImage::from_raw(
         rgba_image.width(),
         rgba_image.height(),
-        rgba_image.into_raw(),
+        rgba_image.to_rgba8().into_vec(),
     )
     .expect("Conversion of PNG -> Raw -> PNG does not fail");
 


### PR DESCRIPTION
Wayland didn't have proper scaling support, as the current implementation `get_scale_factor` only worked for x11.

Using the git release of [libwayshot](https://github.com/waycrate/wayshot/tree/main/libwayshot)
we can get logical and physical sizing of the monitors and calculate the scaling.


## Test

I've only tested it by setting my scaling factor on `sway` to not 1:
```
[src/linux/impl_monitor.rs:233:9] scale_factor = 1.2
```

