### PR TITLE
Implement Send and Sync for ImplWidow of Windows

### DIFF
--- a/src/windows/impl_window.rs
+++ b/src/windows/impl_window.rs
@@ -39,6 +39,9 @@ pub(crate) struct ImplWindow {
     pub hwnd: HWND,
 }
 
+unsafe impl Send for ImplWindow {}
+unsafe impl Sync for ImplWindow {}
+
 fn is_window_cloaked(hwnd: HWND) -> bool {
     unsafe {
         let mut cloaked = 0u32;


### PR DESCRIPTION
Fixes #228. 
As far as I understand, it should be safe to transfer or share HWND across threads, given how HWND is used in this project.

Related: microsoft/windows-rs#3399