### PR TITLE
fix: bump objc2 versions to 0.3.1 or higher to prevent conflicts with 0.3.0 on MacOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,14 +26,14 @@ thiserror = "2.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 dispatch2 = "0.3"
-objc2 = "0.6"
-objc2-app-kit = "0.3"
-objc2-core-foundation = "0.3"
-objc2-core-graphics = "0.3"
-objc2-foundation = "0.3"
-objc2-av-foundation = "0.3"
-objc2-core-media = "0.3"
-objc2-core-video = "0.3"
+objc2 = "0.6.1"
+objc2-app-kit = "0.3.1"
+objc2-core-foundation = "0.3.1"
+objc2-core-graphics = "0.3.1"
+objc2-foundation = "0.3.1"
+objc2-av-foundation = "0.3.1"
+objc2-core-media = "0.3.1"
+objc2-core-video = "0.3.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 widestring = "1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xcap"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 description = "XCap is a cross-platform screen capture library written in Rust. It supports Linux (X11, Wayland), MacOS, and Windows. XCap supports screenshot and video recording (WIP)."
 license = "Apache-2.0"


### PR DESCRIPTION
In my project there was a different library that was using objc2 0.3.0 which caused me to experience errors on MacOS with certain functions not being present. Please find more information about the error attached in the next comment.

So I froze the objc2 and related package versions to 0.3.1 as xcap does not work under 0.3.0 on MacOS.