### PR TITLE
fix: 支持 Ubuntu 25.04

### DIFF
--- a/src/linux/wayland_capture.rs
+++ b/src/linux/wayland_capture.rs
@@ -9,8 +9,9 @@ use zbus::{
 };
 
 use crate::{
+    XCapError,
     error::XCapResult,
-    platform::utils::{get_zbus_portal_request, safe_uri_to_path, wait_zbus_response}, XCapError,
+    platform::utils::{get_zbus_portal_request, safe_uri_to_path, wait_zbus_response},
 };
 
 use super::utils::{get_zbus_connection, png_to_rgba_image};
@@ -52,7 +53,7 @@ fn org_gnome_shell_screenshot(
 
 #[derive(Deserialize, Type, Debug)]
 #[zvariant(signature = "dict")]
-pub struct ScreenshotResponse{
+pub struct ScreenshotResponse {
     uri: zbus::zvariant::OwnedValue,
 }
 
@@ -85,7 +86,11 @@ fn org_freedesktop_portal_screenshot(
 
     let filename = safe_uri_to_path(&match screenshot_response.uri.into() {
         Value::Str(path) => path,
-        _ => return Err(XCapError::new("[org_freedesktop_portal_screenshot] Failed to get file name"))
+        _ => {
+            return Err(XCapError::new(
+                "[org_freedesktop_portal_screenshot] Failed to get file name",
+            ));
+        }
     })?;
     defer!({
         let _ = fs::remove_file(&filename);


### PR DESCRIPTION
通过 org.freedesktop.portal.Screenshot 进行显示器截图操作在 Ubuntu 25.04 解析 Response 会出错