### PR TITLE
fix: Use DesereializeDict for "signature = dict" structs

### DIFF
--- a/src/linux/wayland_capture.rs
+++ b/src/linux/wayland_capture.rs
@@ -2,10 +2,9 @@ use std::{collections::HashMap, env::temp_dir, fmt::Debug, fs, sync::Mutex};
 
 use image::RgbaImage;
 use scopeguard::defer;
-use serde::Deserialize;
 use zbus::{
     blocking::{Connection, Proxy},
-    zvariant::{Type, Value},
+    zvariant::{DeserializeDict, Type, Value},
 };
 
 use crate::{
@@ -51,7 +50,7 @@ fn org_gnome_shell_screenshot(
     Ok(rgba_image)
 }
 
-#[derive(Deserialize, Type, Debug)]
+#[derive(DeserializeDict, Type, Debug)]
 #[zvariant(signature = "dict")]
 pub struct ScreenshotResponse {
     uri: zbus::zvariant::OwnedValue,

--- a/src/linux/wayland_video_recorder.rs
+++ b/src/linux/wayland_video_recorder.rs
@@ -26,10 +26,9 @@ use pipewire::{
     },
     stream::{Stream, StreamFlags},
 };
-use serde::Deserialize;
 use zbus::{
     blocking::Proxy,
-    zvariant::{OwnedFd, OwnedObjectPath, Type, Value},
+    zvariant::{DeserializeDict, OwnedFd, OwnedObjectPath, Type, Value},
 };
 
 use crate::{XCapError, XCapResult, video_recorder::Frame};
@@ -40,7 +39,7 @@ use super::{
 };
 
 #[allow(dead_code)]
-#[derive(Deserialize, Type, Debug)]
+#[derive(DeserializeDict, Type, Debug)]
 #[zvariant(signature = "dict")]
 pub struct ScreenCastStartStream {
     pub id: Option<String>,
@@ -50,7 +49,7 @@ pub struct ScreenCastStartStream {
     pub mapping_id: Option<String>,
 }
 
-#[derive(Deserialize, Type, Debug)]
+#[derive(DeserializeDict, Type, Debug)]
 #[zvariant(signature = "dict")]
 pub struct ScreenCastStartResponse {
     pub streams: Option<Vec<(u32, ScreenCastStartStream)>>,


### PR DESCRIPTION
I have not worked with `zbus` before, but this seems correct.

I can't not attribute this to being some NixOS quirk, but it seems like using `DeserializeDict` should be the default as per [the `zvariant` docs](https://docs.rs/zvariant/latest/zvariant/derive.DeserializeDict.html#alternative-approaches), given the code in `ScreenCastStartResponse`, `ScreenCastStartStream` and `ScreenshotResponse` does not have the noted `#[serde(with = "as_value...")]` entries, so I assume this was the intended way it should be done.

I have tested screen recording on wayland to work after this fix.

Fixes #235