### PR TITLE
fix: consume SelectSources response signal on Wayland

### DIFF
--- a/src/linux/wayland_video_recorder.rs
+++ b/src/linux/wayland_video_recorder.rs
@@ -134,7 +134,9 @@ impl ScreenCast<'_> {
         self.proxy
             .call_method("SelectSources", &(session, options))?;
 
-        portal_request.receive_signal("Response")?;
+        let mut signals = portal_request.receive_signal("Response")?;
+        // If the iterator is not consumed xdg-desktop-portal-hyprland invalidates the session
+        let _msg = signals.next();
 
         Ok(())
     }


### PR DESCRIPTION
Consumes the iterator yielded by `portal_request.receive_signal`. Without this, on xdg-desktop-portal-hyprland drops the screencast session.