### PR TITLE
Update dependencies and patch xcb for security vulnerabilities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,12 +72,18 @@ zbus = "5.17"
 rand = "0.10"
 serde = "1.0"
 pipewire = "0.10"
-libwayshot-xcap = "0.3"
+libwayshot-xcap = { git = "https://github.com/nashaofu/wayshot", branch = "main", package = "libwayshot-xcap"}
 percent-encoding = "2.3"
 xcb = { version = "1.7", features = ["randr"] }
 
 [dev-dependencies]
 fs_extra = "1.3"
+
+# Force xcb build-dep off quick-xml 0.30.0 to mitigate RUSTSEC-2026-0194/0195.
+# Upstream master bumps quick-xml to 0.41 but is unreleased on crates.io.
+# Remove once rust-xcb publishes a release with quick-xml >= 0.41.
+[patch.crates-io]
+xcb = { git = "https://github.com/rust-x-bindings/rust-xcb.git", branch = "main" }
 
 [target.'cfg(target_os="windows")'.dev-dependencies]
 windows = { version = "0.62", features = ["Win32_UI_HiDpi"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["screen", "monitor", "window", "capture", "image"]
 
 [workspace]
 members = ["."]
-resolver = "2"
+resolver = "3"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -68,13 +68,13 @@ windows = { version = "0.62", features = [
 
 [target.'cfg(all(target_os = "linux", not(target_env = "ohos")))'.dependencies]
 url = "2.5"
-zbus = "5.6"
-rand = "0.9"
+zbus = "5.17"
+rand = "0.10"
 serde = "1.0"
-pipewire = "0.9"
+pipewire = "0.10"
 libwayshot-xcap = "0.3"
 percent-encoding = "2.3"
-xcb = { version = "1.5", features = ["randr"] }
+xcb = { version = "1.7", features = ["randr"] }
 
 [dev-dependencies]
 fs_extra = "1.3"

--- a/src/linux/wayland_video_recorder.rs
+++ b/src/linux/wayland_video_recorder.rs
@@ -292,8 +292,11 @@ impl WaylandVideoRecorder {
                                     VideoFormat::RGB => {
                                         let mut buf =
                                             vec![0; (size.width * size.height * 4) as usize];
-                                        for (src, dst) in
-                                            frame_data.chunks_exact(3).zip(buf.chunks_exact_mut(4))
+                                        for (src, dst) in frame_data
+                                            .as_chunks::<3>()
+                                            .0
+                                            .iter()
+                                            .zip(buf.as_chunks_mut::<4>().0)
                                         {
                                             dst[0] = src[0];
                                             dst[1] = src[1];
@@ -307,7 +310,7 @@ impl WaylandVideoRecorder {
                                     VideoFormat::RGBx => frame_data.to_vec(),
                                     VideoFormat::BGRx => {
                                         let mut buf = frame_data.to_vec();
-                                        for src in buf.chunks_exact_mut(4) {
+                                        for src in buf.as_chunks_mut::<4>().0 {
                                             src.swap(0, 2);
                                         }
 


### PR DESCRIPTION
## Summary

Mitigates RUSTSEC-2026-0194 and RUSTSEC-2026-0195 (high severity, both
in `quick-xml <0.41`) by patching `xcb` to upstream `master` until a
crates.io release is published.


## What changed

- Added `[patch.crates-io] xcb = { git = "rust-x-bindings/rust-xcb", branch = "main" }`.
  Upstream master bumps xcb's `build-dependencies.quick-xml` from
  `0.30.0` to `0.41`, picking up both fixes.
- `libwayshot-xcap` line was rewritten by `cargo update` to the explicit
  git source form to match the already-resolved registry entry. No
  functional change; it already pulled from `nashaofu/wayshot@main`
  (the published 0.3.2 on crates.io is git-sourced from that branch).

## Out of scope (intentionally not patched)

- `quick-xml 0.39.4` via `wayland-scanner` (proc-macro from wayland-rs).
  Smithay's `wayland-rs` master also bumps to 0.41, but patching the
  full `wayland-{scanner,client,server,backend}` monorepo triggers an
  ABI break in `gbm 0.18.0` (`Interface::id()` now returns
  `Result<NonNull<c_void>, InvalidId>` instead of `NonNull<c_void>`),
  which would also require patching `gbm` and `libwayshot-xcap`.
  Tracking this as a follow-up: depends on Smithay publishing a
  coordinated release that downstream `gbm` can adopt.
- `paste 1.0.15` (RUSTSEC-2024-0436, unmaintained warning, not a
  vulnerability). Transitive via the dev-dep tree; no fix available.
- Potential changes need to be made to `gbm` under `libwayshot-xcap` and making patches there instead.

## Removal

Drop the `[patch.crates-io]` block (and revert the auto-normalized
`libwayshot-xcap` line if desired) once `rust-x-bindings/rust-xcb`
publishes a crates-io release that pins `quick-xml >= 0.41`.

## Verification
```
$ cargo audit
... Scanning Cargo.lock for vulnerabilities (320 crate dependencies)
warning: 1 allowed warning found     # paste unmaintained, pre-existing
$ cargo build --workspace
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 10.44s
$ cargo +nightly clippy --workspace --all-targets --all-features --locked -- -D warnings -W clippy::perf
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 10.01s
```

Refs: RUSTSEC-2026-0194, RUSTSEC-2026-0195
