### PR TITLE
fix(linux): reuse portal proxy connection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xcap"
-version = "0.9.7"
+version = "0.9.8"
 edition = "2024"
 description = "XCap is a cross-platform screen capture library written in Rust. It supports Linux (X11, Wayland), MacOS, Windows, and HarmonyOS (OpenHarmony/OHOS). XCap supports screenshot and video recording (WIP)."
 license = "Apache-2.0"

--- a/src/linux/wayland_video_recorder.rs
+++ b/src/linux/wayland_video_recorder.rs
@@ -85,12 +85,12 @@ impl ScreenCast<'_> {
     }
 
     pub fn create_session(&self) -> XCapResult<OwnedObjectPath> {
-        let conn = get_zbus_connection()?;
+        let conn = self.proxy.connection();
 
         let mut options = HashMap::new();
 
         let handle_token = rand::random::<u32>().to_string();
-        let portal_request = get_zbus_portal_request(&conn, &handle_token)?;
+        let portal_request = get_zbus_portal_request(conn, &handle_token)?;
 
         options.insert("handle_token", Value::from(&handle_token));
 
@@ -120,12 +120,12 @@ impl ScreenCast<'_> {
     }
 
     pub fn select_sources(&self, session: &OwnedObjectPath) -> XCapResult<()> {
-        let conn = get_zbus_connection()?;
+        let conn = self.proxy.connection();
 
         let mut options = HashMap::new();
 
         let handle_token = rand::random::<u32>().to_string();
-        let portal_request = get_zbus_portal_request(&conn, &handle_token)?;
+        let portal_request = get_zbus_portal_request(conn, &handle_token)?;
 
         options.insert("handle_token", Value::from(handle_token));
         options.insert("types", Value::from(1_u32));
@@ -140,12 +140,12 @@ impl ScreenCast<'_> {
     }
 
     pub fn start(&self, session: &OwnedObjectPath) -> XCapResult<ScreenCastStartResponse> {
-        let conn = get_zbus_connection()?;
+        let conn = self.proxy.connection();
 
         let mut options = HashMap::new();
 
         let handle_token = rand::random::<u32>().to_string();
-        let portal_request = get_zbus_portal_request(&conn, &handle_token)?;
+        let portal_request = get_zbus_portal_request(conn, &handle_token)?;
 
         options.insert("handle_token", Value::from(&handle_token));
 


### PR DESCRIPTION
## Summary

- reuse the `ScreenCast` proxy's D-Bus connection when creating portal request proxies
- keep the request path's unique connection identifier aligned with the connection that sends `CreateSession`, `SelectSources`, and `Start`
- prevent Wayland screen recording from waiting indefinitely without showing the source selection portal

## Verification

- `cargo fmt --check`
- `git diff --check`
- `cargo check --all-targets`

Closes #283
