### PR TITLE
refactor: use ashpd library instead of zbus directly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ windows = { version = "0.62", features = [
 
 [target.'cfg(all(target_os = "linux", not(target_env = "ohos")))'.dependencies]
 url = "2.5"
-ashpd = { version = "0.13", default-features = false, features = ["async-io", "pipewire", "screencast", "screenshot"] }
+ashpd = { git = "https://github.com/bilelmoussaoui/ashpd.git", branch = "main", default-features = false, features = ["async-io", "pipewire", "screencast", "screenshot"] }
 pollster = "1.0"
 rand = "0.10"
 serde = "1.0"
@@ -85,9 +85,6 @@ fs_extra = "1.3"
 # Remove once rust-xcb publishes a release with quick-xml >= 0.41.
 [patch.crates-io]
 xcb = { git = "https://github.com/rust-x-bindings/rust-xcb.git", branch = "main" }
-
-# Remove once ashpd publishes support for pipewire >= 0.10
-ashpd = { git = "https://github.com/bilelmoussaoui/ashpd.git", branch = "main" }
 
 [target.'cfg(target_os="windows")'.dev-dependencies]
 windows = { version = "0.62", features = ["Win32_UI_HiDpi"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ windows = { version = "0.62", features = [
 
 [target.'cfg(all(target_os = "linux", not(target_env = "ohos")))'.dependencies]
 url = "2.5"
-ashpd = { git = "https://github.com/bilelmoussaoui/ashpd", branch = "main", default-features = false, features = ["async-io", "pipewire", "screencast", "screenshot"] }
+ashpd = { version = "0.13", default-features = false, features = ["async-io", "pipewire", "screencast", "screenshot"] }
 pollster = "1.0"
 rand = "0.10"
 serde = "1.0"
@@ -85,6 +85,9 @@ fs_extra = "1.3"
 # Remove once rust-xcb publishes a release with quick-xml >= 0.41.
 [patch.crates-io]
 xcb = { git = "https://github.com/rust-x-bindings/rust-xcb.git", branch = "main" }
+
+# Remove once ashpd publishes support for pipewire >= 0.10
+ashpd = { git = "https://github.com/bilelmoussaoui/ashpd.git", branch = "main" }
 
 [target.'cfg(target_os="windows")'.dev-dependencies]
 windows = { version = "0.62", features = ["Win32_UI_HiDpi"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,8 @@ windows = { version = "0.62", features = [
 [target.'cfg(all(target_os = "linux", not(target_env = "ohos")))'.dependencies]
 url = "2.5"
 zbus = "5.17"
+ashpd = { git = "https://github.com/bilelmoussaoui/ashpd", branch = "main", default-features = false, features = ["async-io", "screencast", "pipewire"] }
+pollster = "1.0"
 rand = "0.10"
 serde = "1.0"
 pipewire = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,8 +68,7 @@ windows = { version = "0.62", features = [
 
 [target.'cfg(all(target_os = "linux", not(target_env = "ohos")))'.dependencies]
 url = "2.5"
-zbus = "5.17"
-ashpd = { git = "https://github.com/bilelmoussaoui/ashpd", branch = "main", default-features = false, features = ["async-io", "screencast", "pipewire"] }
+ashpd = { git = "https://github.com/bilelmoussaoui/ashpd", branch = "main", default-features = false, features = ["async-io", "pipewire", "screencast", "screenshot"] }
 pollster = "1.0"
 rand = "0.10"
 serde = "1.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,9 +27,6 @@ pub enum XCapError {
     StdStringFromUtf8Error(#[from] std::string::FromUtf8Error),
     #[cfg(all(target_os = "linux", not(target_env = "ohos")))]
     #[error(transparent)]
-    ZbusError(#[from] zbus::Error),
-    #[cfg(all(target_os = "linux", not(target_env = "ohos")))]
-    #[error(transparent)]
     StdIOError(#[from] std::io::Error),
     #[cfg(all(target_os = "linux", not(target_env = "ohos")))]
     #[error(transparent)]
@@ -43,9 +40,6 @@ pub enum XCapError {
     #[cfg(all(target_os = "linux", not(target_env = "ohos")))]
     #[error(transparent)]
     UrlParseError(#[from] url::ParseError),
-    #[cfg(all(target_os = "linux", not(target_env = "ohos")))]
-    #[error(transparent)]
-    ZbusZvariantError(#[from] zbus::zvariant::Error),
     #[cfg(all(target_os = "linux", not(target_env = "ohos")))]
     #[error(transparent)]
     PipewireError(#[from] pipewire::Error),

--- a/src/linux/utils.rs
+++ b/src/linux/utils.rs
@@ -1,21 +1,15 @@
 use std::{
     env::{self, var_os},
     path::{Path, PathBuf},
-    sync::mpsc::Receiver,
 };
 
 use image::{RgbaImage, open};
 use percent_encoding::percent_decode_str;
-use serde::Deserialize;
 use url::Url;
 use xcb::{
     Connection as XcbConnection, Xid,
     randr::{GetMonitors, MonitorInfoBuf, Output},
     x::{Atom, InternAtom, ScreenBuf},
-};
-use zbus::{
-    blocking::{Connection as ZBusConnection, Proxy},
-    zvariant::Type,
 };
 
 use crate::{XCapError, error::XCapResult};
@@ -26,10 +20,6 @@ pub fn get_xcb_connection_and_index() -> XCapResult<(XcbConnection, i32)> {
         .or_else(|_| XcbConnection::connect(None))
         .map_err(|e| XCapError::new(e.to_string()))?;
     Ok((conn, idx))
-}
-
-pub fn get_zbus_connection() -> XCapResult<ZBusConnection> {
-    ZBusConnection::session().map_err(XCapError::ZbusError)
 }
 
 pub fn wayland_detect() -> bool {
@@ -130,68 +120,4 @@ pub(super) fn safe_uri_to_path(uri: &str) -> XCapResult<PathBuf> {
     let path = PathBuf::from(&decoded_path);
 
     Ok(path)
-}
-
-pub(super) fn get_zbus_portal_request(
-    conn: &ZBusConnection,
-    handle_token: &str,
-) -> XCapResult<Proxy<'static>> {
-    let unique_identifier = conn
-        .unique_name()
-        .ok_or(XCapError::new("Get DBus unique name failed"))?
-        .trim_start_matches(':')
-        .replace('.', "_");
-
-    let path =
-        format!("/org/freedesktop/portal/desktop/request/{unique_identifier}/{handle_token}");
-
-    let request = Proxy::new(
-        conn,
-        "org.freedesktop.portal.Desktop",
-        path,
-        "org.freedesktop.portal.Request",
-    )?;
-
-    Ok(request)
-}
-
-pub(super) fn wait_zbus_response<T>(request: &Proxy<'static>) -> Receiver<XCapResult<T>>
-where
-    T: for<'de> Deserialize<'de> + Type + Send + Sync + 'static,
-{
-    let (sender, receiver) = std::sync::mpsc::channel();
-
-    let request = request.clone();
-    std::thread::spawn(move || {
-        let response = wait_zbus_response_inner::<T>(&request);
-        sender
-            .send(response)
-            .map_err(|e| XCapError::new(format!("Failed to send zbus response: {e}")))
-    });
-
-    receiver
-}
-
-pub(super) fn wait_zbus_response_inner<'a, T>(request: &Proxy<'a>) -> XCapResult<T>
-where
-    T: for<'de> Deserialize<'de> + Type,
-{
-    let mut response = request.receive_signal("Response")?;
-
-    let message = response
-        .next()
-        .ok_or(XCapError::new("Failed get response"))?;
-
-    let body = message.body();
-    let (code, body): (u32, T) = body.deserialize()?;
-
-    if code == 0 {
-        return Ok(body);
-    }
-
-    if code == 1 {
-        return Err(XCapError::new("Z-Bus canceled"));
-    }
-
-    Err(XCapError::new(format!("Response code is {code}")))
 }

--- a/src/linux/wayland_capture.rs
+++ b/src/linux/wayland_capture.rs
@@ -1,32 +1,33 @@
-use std::{collections::HashMap, env::temp_dir, fmt::Debug, fs, sync::Mutex};
+use std::{env::temp_dir, fs, sync::Mutex};
 
+use ashpd::{
+    desktop::screenshot::Screenshot,
+    zbus::{self, Connection},
+};
 use image::RgbaImage;
 use scopeguard::defer;
-use zbus::{
-    blocking::{Connection, Proxy},
-    zvariant::{DeserializeDict, Type, Value},
-};
 
+use super::utils::png_to_rgba_image;
 use crate::{
-    error::XCapResult,
-    platform::utils::{get_zbus_portal_request, safe_uri_to_path, wait_zbus_response},
+    error::{XCapError, XCapResult},
+    platform::utils::safe_uri_to_path,
 };
 
-use super::utils::{get_zbus_connection, png_to_rgba_image};
-
-fn org_gnome_shell_screenshot(
+async fn org_gnome_shell_screenshot(
     conn: &Connection,
     x: i32,
     y: i32,
     width: i32,
     height: i32,
 ) -> XCapResult<RgbaImage> {
-    let proxy = Proxy::new(
+    let proxy = zbus::Proxy::new(
         conn,
         "org.gnome.Shell.Screenshot",
         "/org/gnome/Shell/Screenshot",
         "org.gnome.Shell.Screenshot",
-    )?;
+    )
+    .await
+    .map_err(|e| XCapError::new(e.to_string()))?;
 
     let filename = rand::random::<u32>();
 
@@ -42,48 +43,33 @@ fn org_gnome_shell_screenshot(
     let filename = path.to_string_lossy().to_string();
 
     // https://github.com/vinzenz/gnome-shell/blob/master/data/org.gnome.Shell.Screenshot.xml
-    proxy.call_method("ScreenshotArea", &(x, y, width, height, false, &filename))?;
+    proxy
+        .call_method("ScreenshotArea", &(x, y, width, height, false, &filename))
+        .await
+        .map_err(|e| XCapError::new(e.to_string()))?;
 
     let rgba_image = png_to_rgba_image(&filename, 0, 0, width, height)?;
 
     Ok(rgba_image)
 }
 
-#[derive(DeserializeDict, Type, Debug)]
-#[zvariant(signature = "dict")]
-pub struct ScreenshotResponse {
-    uri: String,
-}
-
 /// https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Screenshot.html
-fn org_freedesktop_portal_screenshot(
-    conn: &Connection,
+async fn org_freedesktop_portal_screenshot(
     x: i32,
     y: i32,
     width: i32,
     height: i32,
 ) -> XCapResult<RgbaImage> {
-    let proxy = Proxy::new(
-        conn,
-        "org.freedesktop.portal.Desktop",
-        "/org/freedesktop/portal/desktop",
-        "org.freedesktop.portal.Screenshot",
-    )?;
+    let screenshot_response = Screenshot::request()
+        .interactive(false)
+        .send()
+        .await
+        .map_err(|e| XCapError::new(e.to_string()))?
+        .response()
+        .map_err(|e| XCapError::new(e.to_string()))?;
 
-    let handle_token = rand::random::<u32>().to_string();
-    let portal_request = get_zbus_portal_request(conn, &handle_token)?;
+    let filename = safe_uri_to_path(screenshot_response.uri().as_str())?;
 
-    let mut options: HashMap<&str, Value> = HashMap::new();
-    options.insert("handle_token", Value::from(&handle_token));
-    options.insert("modal", Value::from(true));
-    options.insert("interactive", Value::from(false));
-
-    let receiver = wait_zbus_response(&portal_request);
-
-    // https://github.com/flatpak/xdg-desktop-portal/blob/main/data/org.freedesktop.portal.Screenshot.xml
-    proxy.call_method("Screenshot", &("", options))?;
-    let screenshot_response: ScreenshotResponse = receiver.recv()??;
-    let filename = safe_uri_to_path(&screenshot_response.uri)?;
     defer!({
         let _ = fs::remove_file(&filename);
     });
@@ -131,17 +117,22 @@ fn wlroots_screenshot(
 pub fn wayland_capture(x: i32, y: i32, width: i32, height: i32) -> XCapResult<RgbaImage> {
     let lock = DBUS_LOCK.lock();
 
-    let conn = get_zbus_connection()?;
-    let res = org_gnome_shell_screenshot(&conn, x, y, width, height)
-        .or_else(|e| {
-            log::debug!("org_gnome_shell_screenshot failed {e}");
-
-            org_freedesktop_portal_screenshot(&conn, x, y, width, height)
-        })
-        .or_else(|e| {
-            log::debug!("org_freedesktop_portal_screenshot failed {e}");
-            wlroots_screenshot(x, y, width, height)
-        });
+    let res = pollster::block_on(async {
+        let conn = zbus::Connection::session()
+            .await
+            .map_err(|e| XCapError::new(e.to_string()))?;
+        match org_gnome_shell_screenshot(&conn, x, y, width, height).await {
+            Ok(img) => Ok(img),
+            Err(e) => {
+                log::debug!("org_gnome_shell_screenshot failed {e}");
+                org_freedesktop_portal_screenshot(x, y, width, height).await
+            }
+        }
+    })
+    .or_else(|e| {
+        log::debug!("org_freedesktop_portal_screenshot failed {e}");
+        wlroots_screenshot(x, y, width, height)
+    });
 
     drop(lock);
 

--- a/src/linux/wayland_video_recorder.rs
+++ b/src/linux/wayland_video_recorder.rs
@@ -9,7 +9,7 @@ use std::{
     thread,
 };
 
-use ashpd::desktop::screencast::{Screencast, SelectSourcesOptions};
+use ashpd::desktop::screencast::{Screencast, SelectSourcesOptions, SourceType};
 
 use pipewire::{
     channel,
@@ -74,7 +74,11 @@ impl WaylandVideoRecorder {
                 .map_err(|e| XCapError::new(e.to_string()))?;
 
             proxy
-                .select_sources(&session, SelectSourcesOptions::default())
+                .select_sources(
+                    &session,
+                    SelectSourcesOptions::default()
+                        .set_sources(SourceType::Monitor | SourceType::Window),
+                )
                 .await
                 .map_err(|e| XCapError::new(e.to_string()))?;
 

--- a/src/linux/wayland_video_recorder.rs
+++ b/src/linux/wayland_video_recorder.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::HashMap,
     fmt,
     io::Cursor,
     sync::{
@@ -9,6 +8,8 @@ use std::{
     },
     thread,
 };
+
+use ashpd::desktop::screencast::{Screencast, SelectSourcesOptions};
 
 use pipewire::{
     channel,
@@ -28,142 +29,9 @@ use pipewire::{
     },
     stream::{StreamFlags, StreamRc},
 };
-use zbus::{
-    blocking::Proxy,
-    zvariant::{DeserializeDict, OwnedFd, OwnedObjectPath, Type, Value},
-};
 
+use super::impl_monitor::ImplMonitor;
 use crate::{XCapError, XCapResult, video_recorder::Frame};
-
-use super::{
-    impl_monitor::ImplMonitor,
-    utils::{get_zbus_connection, get_zbus_portal_request, wait_zbus_response},
-};
-
-#[allow(dead_code)]
-#[derive(DeserializeDict, Type, Debug)]
-#[zvariant(signature = "dict")]
-pub struct ScreenCastCreateSessionResponse {
-    session_handle: String,
-}
-
-#[allow(dead_code)]
-#[derive(DeserializeDict, Type, Debug)]
-#[zvariant(signature = "dict")]
-pub struct ScreenCastStartStream {
-    pub id: Option<String>,
-    pub position: Option<(i32, i32)>,
-    pub size: Option<(i32, i32)>,
-    pub source_type: Option<u32>,
-    pub mapping_id: Option<String>,
-}
-
-#[derive(DeserializeDict, Type, Debug)]
-#[zvariant(signature = "dict")]
-pub struct ScreenCastStartResponse {
-    pub streams: Option<Vec<(u32, ScreenCastStartStream)>>,
-    #[allow(dead_code)]
-    pub restore_token: Option<String>,
-}
-
-/// https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.ScreenCast.html
-pub struct ScreenCast<'a> {
-    proxy: Proxy<'a>,
-}
-
-impl ScreenCast<'_> {
-    pub fn new() -> XCapResult<Self> {
-        let conn = get_zbus_connection()?;
-        let proxy = Proxy::new(
-            &conn,
-            "org.freedesktop.portal.Desktop",
-            "/org/freedesktop/portal/desktop",
-            "org.freedesktop.portal.ScreenCast",
-        )?;
-
-        Ok(ScreenCast { proxy })
-    }
-
-    pub fn create_session(&self) -> XCapResult<OwnedObjectPath> {
-        let conn = self.proxy.connection();
-
-        let mut options = HashMap::new();
-
-        let handle_token = rand::random::<u32>().to_string();
-        let portal_request = get_zbus_portal_request(conn, &handle_token)?;
-
-        options.insert("handle_token", Value::from(&handle_token));
-
-        let session_handle_token = rand::random::<u32>().to_string();
-        options.insert("session_handle_token", Value::from(&session_handle_token));
-
-        let receiver = wait_zbus_response::<ScreenCastCreateSessionResponse>(&portal_request);
-
-        self.proxy.call_method("CreateSession", &(options))?;
-
-        let response = receiver.recv()??;
-
-        let unique_name = conn
-            .unique_name()
-            .ok_or(XCapError::new("Failed to get unique name"))?;
-        let unique_identifier = unique_name.trim_start_matches(':').replace('.', "_");
-
-        let session = OwnedObjectPath::try_from(format!(
-            "/org/freedesktop/portal/desktop/session/{unique_identifier}/{session_handle_token}"
-        ))?;
-
-        if session.as_str() != response.session_handle {
-            return Err(XCapError::new("Session handle mismatch"));
-        }
-
-        Ok(session)
-    }
-
-    pub fn select_sources(&self, session: &OwnedObjectPath) -> XCapResult<()> {
-        let conn = self.proxy.connection();
-
-        let mut options = HashMap::new();
-
-        let handle_token = rand::random::<u32>().to_string();
-        let portal_request = get_zbus_portal_request(conn, &handle_token)?;
-
-        options.insert("handle_token", Value::from(handle_token));
-        options.insert("types", Value::from(1_u32));
-        options.insert("multiple", Value::from(false));
-
-        self.proxy
-            .call_method("SelectSources", &(session, options))?;
-
-        portal_request.receive_signal("Response")?;
-
-        Ok(())
-    }
-
-    pub fn start(&self, session: &OwnedObjectPath) -> XCapResult<ScreenCastStartResponse> {
-        let conn = self.proxy.connection();
-
-        let mut options = HashMap::new();
-
-        let handle_token = rand::random::<u32>().to_string();
-        let portal_request = get_zbus_portal_request(conn, &handle_token)?;
-
-        options.insert("handle_token", Value::from(&handle_token));
-
-        let receiver = wait_zbus_response(&portal_request);
-
-        self.proxy.call_method("Start", &(session, "", options))?;
-
-        receiver.recv()?
-    }
-
-    #[allow(dead_code)]
-    pub fn open_pipe_wire_remote(&self, session: &OwnedObjectPath) -> XCapResult<OwnedFd> {
-        let options: HashMap<&str, Value<'_>> = HashMap::new();
-        let fd: OwnedFd = self.proxy.call("OpenPipeWireRemote", &(session, options))?;
-
-        Ok(fd)
-    }
-}
 
 #[derive(Clone)]
 pub struct WaylandVideoRecorder {
@@ -186,7 +54,6 @@ impl fmt::Debug for WaylandVideoRecorder {
     }
 }
 
-#[derive(Clone)]
 struct ListenerUserData {
     pub format: VideoInfoRaw,
 }
@@ -196,18 +63,38 @@ impl WaylandVideoRecorder {
         let (sender, receiver) = mpsc::channel();
         let (active_sender, active_receiver) = channel::channel();
 
-        let screen_cast = ScreenCast::new()?;
-        let session = screen_cast.create_session()?;
-        screen_cast.select_sources(&session)?;
-        let response = screen_cast.start(&session)?;
+        let stream = pollster::block_on(async {
+            let proxy = Screencast::new()
+                .await
+                .map_err(|e| XCapError::new(e.to_string()))?;
 
-        // 获取流节点ID
-        let stream_id = response
-            .streams
-            .ok_or(XCapError::new("Stream ID not found"))?
-            .first()
-            .ok_or(XCapError::new("Stream ID not found"))?
-            .0;
+            let session = proxy
+                .create_session(Default::default())
+                .await
+                .map_err(|e| XCapError::new(e.to_string()))?;
+
+            proxy
+                .select_sources(&session, SelectSourcesOptions::default())
+                .await
+                .map_err(|e| XCapError::new(e.to_string()))?;
+
+            let response = proxy
+                .start(&session, None, Default::default())
+                .await
+                .map_err(|e| XCapError::new(e.to_string()))?
+                .response()
+                .map_err(|e| XCapError::new(e.to_string()))?;
+
+            let stream = response
+                .streams()
+                .first()
+                .ok_or_else(|| XCapError::new("no stream found / selected"))?
+                .to_owned();
+
+            Ok::<ashpd::desktop::screencast::Stream, XCapError>(stream)
+        })?;
+
+        let stream_id = stream.pipe_wire_node_id();
 
         let recorder = Self {
             monitor,


### PR DESCRIPTION
This was primarly to fix #285. I tried to directly fix the zbus calls, but I gave up and used ashpd

I took the time to also change the screenshot but kept the gnome related stuff (can't test, I'm on KDE)

